### PR TITLE
Add 'repeats' parameter to zoned cleanup

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -436,27 +436,28 @@ MqttClient.prototype.handleCustomCommand = function (message) {
                 if (Array.isArray(msg.zone_ids)) {
                     const areas = this.configuration.get("areas");
                     let zones = [];
-                    var repeats_override = null;
-                    if (typeof msg.repeats !== "undefined") {
-                        let repeats = Number(msg.repeats)
-                        if (repeats >= 1 && repeats <= 3) {
-                            console.info(new Date(), "Zone cleanup repeats override:", repeats);
-                            repeats_override = repeats
-                        } else {
-                            console.error(new Date(), "Invalid repeats:", repeats);
-                        }
-                    }
 
-                    msg.zone_ids.forEach(function (zone_id) {
+                    msg.zone_ids.forEach(function (zone_selector) {
+                        let zone_id = typeof zone_selector === 'object' ? zone_selector.id : zone_selector;
+                        let repeats = Number(zone_selector.repeats);
                         let area = areas.find(e => Array.isArray(e) && e[0] === zone_id);
                         if (area && Array.isArray(area[1])) {
+                            var area_repeats = area[1][4];
+                            if (!isNaN(repeats)) {
+                                if (repeats >= 1 && repeats <= 3) {
+                                    console.info(new Date(), "Zone cleanup repeats override for zone '" + zone_id + "': " + repeats);
+                                    area_repeats = repeats;
+                                } else {
+                                    console.error(new Date(), "Invalid repeats for zone '" + zone_id + "': " + repeats);
+                                }
+                            }
                             area[1].forEach(function (zone) {
                                 zones.push([
                                     zone[0],
                                     zone[1],
                                     zone[2],
                                     zone[3],
-                                    repeats_override ? repeats_override : zone[4]
+                                    area_repeats
                                 ]);
                             });
                         }

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -436,12 +436,28 @@ MqttClient.prototype.handleCustomCommand = function (message) {
                 if (Array.isArray(msg.zone_ids)) {
                     const areas = this.configuration.get("areas");
                     let zones = [];
+                    var repeats_override = null;
+                    if (typeof msg.repeats !== "undefined") {
+                        let repeats = Number(msg.repeats)
+                        if (repeats >= 1 && repeats <= 3) {
+                            console.info(new Date(), "Zone cleanup repeats override:", repeats);
+                            repeats_override = repeats
+                        } else {
+                            console.error(new Date(), "Invalid repeats:", repeats);
+                        }
+                    }
 
                     msg.zone_ids.forEach(function (zone_id) {
                         let area = areas.find(e => Array.isArray(e) && e[0] === zone_id);
                         if (area && Array.isArray(area[1])) {
                             area[1].forEach(function (zone) {
-                                zones.push(zone);
+                                zones.push([
+                                    zone[0],
+                                    zone[1],
+                                    zone[2],
+                                    zone[3],
+                                    repeats_override ? repeats_override : zone[4]
+                                ]);
                             });
                         }
                     });


### PR DESCRIPTION
Whenever a custom command `zoned_cleanup` is used via MQTT, vacuum pulls zone definitions from the config file based on given zone names. Number of `repeats` for this cleanup is baked into the zone definitions as 5th coordinate" - this is right now only configurable via config file, and defaults to 1.
This PR adds a parameter to `zoned_cleanup` command - `repeats` - that overrides this value for all referenced zones for this cleanup only.