### PR TITLE
Add switch in webinterface settings: hide forbidden markers and room configuration section

### DIFF
--- a/client/home.html
+++ b/client/home.html
@@ -582,7 +582,8 @@
                     103: i18next.t('home.fanspeedPresets.turbo',"Turbo"),
                     104: i18next.t('home.fanspeedPresets.max',"Max")
                 };
-                if (fn.device.model === "roborock.vacuum.s5") {
+                //hide mop setting only for Gen1 devices
+                if (fn.device.model !== "rockrobo.vacuum.v1") {
                     fanspeedPresets[105] = i18next.t('home.fanspeedPresets.mop',"Mop");
                 }
                 fanspeedButton.innerHTML = "<ons-icon icon=\"fa-superpowers\"></ons-icon> " + (fanspeedPresets[res.fan_power] || `Custom ${res.fan_power}%`);

--- a/client/locales/de.json
+++ b/client/locales/de.json
@@ -425,7 +425,7 @@
             "localizationExt": "wechselt zwischen den verfügbaren Sprachen",
             "style": "Aussehen der Weboberfläche",
             "styleExt": "ändert die Farbe der Weboberfläche",
-            "homeTab": "Home Tab",
+            "homeTab": "Startseite",
             "zonedImmediate": "Zonenreinigung wird sofort ausgeführt",
             "zonedImmediateExt": "ohne vorher zur Karte zu wechseln",
             "gotoImmediate": "Sofort zum Ziel gehen",
@@ -439,6 +439,9 @@
             "disableMapReloadExt": "Entfernt die Schaltfläche zum Erzwingen des Nachladens auf der Karte",
             "disableDynamicButtons": "Deaktiviert die dynamischen Schaltflächen",
             "disableDynamicButtonsExt": "Zeigt nur die grundlegenden Schaltflächen auf der Karte",
+            "zonesTab": "Zonen",
+            "hideForbiddenMarkersAndRooms": "Verbotsmarkierungen und Raumkonfiguration nicht anzeigen",
+            "hideForbiddenMarkersAndRoomsExt": "Blendet die Einstellungen für Verbotsmarkierungen und Räume aus",
             "applyLocalizationConfirm": "Soll die Änderung der Sprache jetzt angewandt werden?",
             "applyStyleConfirm": "Soll die Änderung der Farbe jetzt angewandt werden?",
             "enableMultimapConfirm": "Diese Funktion ist kein Teil der Roborock-Funktionalität, sondern eine Reihe von Hacks. Es kann gut funktionieren, aber auch in unerwarteten Fällen zu einem Zurücksetzen auf die Werkseinstellungen führen. Soll dennoch fortgefahren werden?"

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -439,6 +439,9 @@
             "disableMapReloadExt": "hides force reload button on the map",
             "disableDynamicButtons": "Disable dynamic buttons",
             "disableDynamicButtonsExt": "shows on map basic buttons only",
+            "zonesTab": "Zones tab",
+            "hideForbiddenMarkersAndRooms": "Hide forbidden markers and rooms section",
+            "hideForbiddenMarkersAndRoomsExt": "hides forbidden markers and rooms configuration",
             "applyLocalizationConfirm": "Would you like to apply localization changes now?",
             "applyStyleConfirm": "Would you like to apply color theme changes now?",
             "enableMultimapConfirm": "This feature is not a part of roborock functionality but rather a number of hacks around it. While it may work well, it could also cause a factory reset if something unexpectedly goes wrong. Do you still want to continue?"

--- a/client/settings-web-interface.html
+++ b/client/settings-web-interface.html
@@ -60,12 +60,21 @@
             <div class='right'><ons-switch class="settings-webif-switch" id="settings-webif-hide-map-status"></ons-switch></div>
         </ons-list-item>
         <ons-list-item>
-            <div class='left'><div><div data-i18n="settings.webInterface.disableMapReload">Disable map reload button</div><div class="small" data-i18n="settings.webInterface.disableMapReload">hides force reload button on the map</div></div></div>
+            <div class='left'><div><div data-i18n="settings.webInterface.disableMapReload">Disable map reload button</div><div class="small" data-i18n="settings.webInterface.disableMapReloadExt">hides force reload button on the map</div></div></div>
             <div class='right'><ons-switch class="settings-webif-switch" id="settings-webif-hide-map-reload"></ons-switch></div>
         </ons-list-item>
         <ons-list-item>
             <div class='left'><div><div data-i18n="settings.webInterface.disableDynamicButtons">Disable dynamic buttons</div><div class="small" data-i18n="settings.webInterface.disableDynamicButtonsExt">shows on map basic buttons only</div></div></div>
             <div class='right'><ons-switch class="settings-webif-switch" id="settings-webif-static-map-buttons"></ons-switch></div>
+        </ons-list-item>
+    </ons-list>
+    <ons-list-title style="margin-top:5px;" data-i18n="settings.webInterface.zonesTab">
+        Zones tab
+    </ons-list-title>
+    <ons-list>
+        <ons-list-item>
+            <div class='left'><div><div data-i18n="settings.webInterface.hideForbiddenMarkersAndRooms">Hide forbidden markers and rooms section</div><div class="small" data-i18n="settings.webInterface.hideForbiddenMarkersAndRoomsExt">hides forbidden markers and rooms configuration</div></div></div>
+            <div class='right'><ons-switch class="settings-webif-switch" id="settings-webif-hide-forbbidenmarkers-rooms"></ons-switch></div>
         </ons-list-item>
     </ons-list>
     <ons-list-item>

--- a/client/zones.html
+++ b/client/zones.html
@@ -11,6 +11,7 @@
         <ons-list-item data-i18n="zones.noSpotsConfigured" data-i18n-target=".list-item__center">No spots are configured yet.</ons-list-item>
     </ons-list>
 
+    <div id="forbidden-markers-rooms" style="display: none;">
     <ons-list-title style="margin-top:20px;" data-i18n="zones.headerForbiddenMarkers">Forbidden markers</ons-list-title>
     <ons-list id="spot-list">
          <ons-list-item tappable class="locations-list-item" onclick="switchToForbiddenMarkersEdit()">
@@ -26,6 +27,7 @@
              <label data-i18n="zones.editSegments">Edit rooms</label>
          </ons-list-item>
     </ons-list>
+    </div>
 
     <script>
         let loadingBarZones = document.getElementById('loading-bar-zones');
@@ -350,6 +352,8 @@
 
         ons.getScriptPage().onShow = function () {
             loadingBarZones.setAttribute("indeterminate", "indeterminate");
+            //hide section with forbidden markers and rooms
+            document.getElementById('forbidden-markers-rooms').style.display = fn.webifSettings.hideForbbidenmarkersRooms ? 'none' : '';
             // request map update
             fn.prequest("api/poll_map").then(null, (err) => fn.notificationToastError(err));
             // check for area and go to configuration


### PR DESCRIPTION
I've added a new switch in the webinterface settings for zone tab:
Users of Gen1 devices can use this switch to hide the section for the forbidden markers and the rooms in zones tab since they can't use it anyway.