### PR TITLE
modify telegrambot inline keyboard

### DIFF
--- a/lib/Telegrambot.js
+++ b/lib/Telegrambot.js
@@ -846,14 +846,27 @@ Telegrambot.prototype.inlineKeyboardGenerator = function(type, values, chosen) {
             output.push([back]);
             break;
         default:
-            var isPaused = self.lastState.state === 10 || (self.lastState.state === 2 && self.lastState.in_cleaning > 0); 
+            var isPaused = self.lastState.state === 10 || (self.lastState.state === 2 && self.lastState.in_cleaning > 0);
+            var showMultimap = this.configuration.get("webInterface").showMultimap;
             output = [
                 [{text: self.languageGetter('telegram.buttons.status',"Status"), callback_data: "status"},{text: self.languageGetter('telegram.buttons.map',"Map"), callback_data: "map"},{text: self.languageGetter('telegram.buttons.consumables',"Consumables"), callback_data: "consumables"}],
                 [{text: self.languageGetter('telegram.buttons.start',"Start"), callback_data: "start"},(isPaused ? {text: self.languageGetter('telegram.buttons.resume',"Resume"), callback_data: "resume"} : {text: self.languageGetter('telegram.buttons.pause',"Pause"), callback_data: "pause"}),{text: self.languageGetter('telegram.buttons.stop',"Stop"), callback_data: "stop"}],
-                [{text: self.languageGetter('telegram.buttons.zones',"Zones"), callback_data: "zones_menu"},{text: self.languageGetter('telegram.buttons.spot',"Spot"), callback_data: "spot"},{text: self.languageGetter('telegram.buttons.rooms',"Rooms"), callback_data: "segments_menu"}],
+                [],
                 [{text: self.languageGetter('telegram.buttons.home',"Home"), callback_data: "home"},{text: self.languageGetter('telegram.buttons.findMe',"Find Me"), callback_data: "findme"},{text: self.languageGetter('telegram.buttons.goto',"Goto"), callback_data: "goto_menu"}],
-                [{text: "\u{1F300}", callback_data: "power_menu"},{text: "\u{1F507}", callback_data: "notif_off"},{text: "\u{1F50A}", callback_data: "notif_on"},{text: "\u{1F504}", callback_data: "maps_menu"}]
+                []
             ];
+            //Hide rooms button on Gen1 devices
+            if (self.vacuum.model !== "rockrobo.vacuum.v1") {
+                output[2] = [{text: self.languageGetter('telegram.buttons.zones',"Zones"), callback_data: "zones_menu"},{text: self.languageGetter('telegram.buttons.spot',"Spot"), callback_data: "spot"},{text: self.languageGetter('telegram.buttons.rooms',"Rooms"), callback_data: "segments_menu"}];
+            } else {
+                output[2] = [{text: self.languageGetter('telegram.buttons.zones',"Zones"), callback_data: "zones_menu"},{text: self.languageGetter('telegram.buttons.spot',"Spot"), callback_data: "spot"}];
+            }
+            //Multimap-Button: consider the setting of webinterface
+            if (showMultimap) {
+                output[4] = [{text: "\u{1F300}", callback_data: "power_menu"},{text: "\u{1F507}", callback_data: "notif_off"},{text: "\u{1F50A}", callback_data: "notif_on"},{text: "\u{1F504}", callback_data: "maps_menu"}];
+            } else {
+                output[4] = [{text: "\u{1F300}", callback_data: "power_menu"},{text: "\u{1F507}", callback_data: "notif_off"},{text: "\u{1F50A}", callback_data: "notif_on"}];
+            }
     }
     return JSON.stringify({inline_keyboard: output});
 }


### PR DESCRIPTION
Following https://github.com/rand256/valetudo/pull/121#issuecomment-586677331 I've disabled the rooms-button of telegram inlinekeyboard for all Gen1 devices.

Furthermore I've added an check for the maps reload command button:
If this feature isn't enabled via the webgui-setting, the command button will also not be visible in telegram.