### PR TITLE
Make sure connections to fake cloud IP work

### DIFF
--- a/deployment/etc/rc.local
+++ b/deployment/etc/rc.local
@@ -12,4 +12,6 @@ iptables  -t nat -A OUTPUT -p tcp --dport 80   -d 203.0.113.1 -j DNAT --to-desti
 iptables  -t nat -A OUTPUT -p udp --dport 8053 -d 203.0.113.1 -j DNAT --to-destination 127.0.0.1:8053
 iptables         -A OUTPUT                     -d 203.0.113.1/32  -j REJECT
 ip6tables        -A OUTPUT                     -d 2001:db8::1/128 -j REJECT
+
+ip route add 203.0.113.1 via 127.0.0.1
 ### VALETUDO RC.LOCAL EXIT ###


### PR DESCRIPTION
By adding this route, we make sure the Linux kernel will not reply to packets with "destination unreachable".

The traffic is redirected by the DNAT rules set up before adding the route and outgoing connections are rejected anyway, but in restrictive environments in which the DHCP server does not provide the clients with a router IP (e.g., because we do not want the devices in the network to connect to the Internet), the Linux kernel cannot find a route to the IP and replies to the socket's process with a "destination unreachable" ICMP packet. Therefore the entire iptables DNAT cannot redirect the traffic to the dustcloud or, on newer images, cloud-dnsmasq.
It doesn't matter that the route would never work. As long as there is a route, the sockets can send messages, iptables will redirect the traffic for the relevant ports, and any other connection is rejected anyway.

This change is based on the results gathered in https://github.com/rand256/valetudo/issues/139.