### PR TITLE
adding an explanation popover for firmware update function

### DIFF
--- a/client/locales/de.json
+++ b/client/locales/de.json
@@ -325,7 +325,9 @@
             "firmwareUpdateEnterURL": "Bitte geben Sie den Link zur Firmware-Paketdatei ein:",
             "firmwareUpdateEnterMD5": "Bitte geben Sie den MD5-Hash der soeben angegebenen Datei ein:",
             "firmwareUpdateSend": "Absenden!",
-            "firmwareUpdateSentOK": "Update-Anfrage sollte gesendet sein! Warten Sie auf die LED-Anzeige des Update-Vorgangs."
+            "firmwareUpdateSentOK": "Update-Anfrage sollte gesendet sein! Warten Sie auf die LED-Anzeige des Update-Vorgangs.",
+            "exp_fw_update": "Mit dieser Funktion wird die Basisfirmware des Roboters durch das Flashen einer Firmwaredatei (*.pkg) überschrieben. Bei der neuen Firmware kann es sich um eine originale, gerootete oder eine bereits mit Valetudo modifizierten Version handeln. Für die erfolgreiche Durchführung ist eine öffentlich erreichbare http-Linkadresse zur pkg-Datei sowie der zugehörige MD5-Hash-Wert notwendig.",
+            "close": "Schließen"
         },
         "persistentData": {
             "pageTitle": "\"Dauerhafte Daten\"-Konfiguration",

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -325,7 +325,9 @@
             "firmwareUpdateEnterURL": "Please enter URL to firmware pkg file:",
             "firmwareUpdateEnterMD5": "Please enter MD5 hash of the file you just specified:",
             "firmwareUpdateSend": "Send!",
-            "firmwareUpdateSentOK": "Update request should be sent! Wait for LED indication of update process."
+            "firmwareUpdateSentOK": "Update request should be sent! Wait for LED indication of update process.",
+            "exp_fw_update": "This function will override the base firmware of the robot by flashing a firmwarefile (*.pkg). The new firmware version can be stock, rooted or enhanced with valetudo. You'll need a public http-link address to the pkg-file and the corresponding MD5 hash value to successfully complete the process.",
+            "close": "Close"
         },
         "persistentData": {
             "pageTitle": "Persistent Data Configuration",

--- a/client/settings-info.html
+++ b/client/settings-info.html
@@ -33,6 +33,7 @@
 			</div>
 			<div class="right" id="info_fw_update">
 				<a id="sendUpdateRequestButton" onclick="sendUpdateRequest();" data-i18n="settings.info.firmwareUpdateLink">[send request]</a>
+				<a id="UpdateRequestExplanation" onclick="showPopover(this);" <i class="far fa-question-circle"></i></a>
 			</div>
 		</ons-list-item>
 	</ons-list>
@@ -127,6 +128,14 @@
 			</div>
 		</ons-list-item>
 	</ons-list>
+	<ons-popover direction="left" id="exp_fw_update" cancelable>
+		<div style="padding: 5px; text-align: center;">
+			<p><span data-i18n="settings.info.exp_fw_update">This function will override the base firmware of the robot by flashing a firmwarefile (*.pkg). The new firmware version can be stock, rooted or enhanced with valetudo. You'll need a public http-link address to the pkg-file and the corresponding MD5 hash value to successfully complete the process.</span></p>
+			<p>
+				<ons-button onclick="hidePopover()" data-i18n="settings.info.close">Close</ons-button>
+			</p>
+		</div>
+	</ons-popover>
 
 	<script>
 		var loadingBarSettingsInfo = document.getElementById('loading-bar-settings-info');
@@ -156,6 +165,18 @@
 				document.getElementById('current-token-label').innerHTML = res.token;
 			}, (err) => fn.notificationToastError(err));
 			Promise.all([updateSystemInfo, updateAppLocaleInfo, updateCurrentTokenInfo]).finally(() => loadingBarSettingsInfo.removeAttribute("indeterminate"));
+		};
+		
+		var showPopover = function(target) {
+			document
+			.getElementById('exp_fw_update')
+			.show(target);
+		};
+
+		var hidePopover = function() {
+			document
+			.getElementById('exp_fw_update')
+			.hide();
 		};
 
 		function sendUpdateRequest() {
@@ -232,6 +253,9 @@
 			color: blue;
 			text-decoration: underline;
 			cursor: pointer;
+		}
+		#UpdateRequestExplanation {
+			padding: 0 0.5em;
 		}
 	</style>
 </ons-page>


### PR DESCRIPTION
because of the user questions in the last days after releasing the new valetudo version I've added a questionmark symbol after the [send request] command in settings/info that opens an popover giving a short explanation what's the function about and the prerequisites to successfull flash the robot.