### PR TITLE
more fixes for dark theme on chromium mobile needed

### DIFF
--- a/client/css/dark.css
+++ b/client/css/dark.css
@@ -48,6 +48,10 @@ button.fab:active, ons-fab.fab:active, ons-speed-dial-item.fab:active {
     background-color: #9a9a9a;
 }
 
+.range--material__input {
+     background-image: linear-gradient(#0076ff,#0076ff);
+}
+
 ons-select option {
     background-color: #9a9a9a;
 }


### PR DESCRIPTION
While checking the dark theme on my mobile browser, I've found some errors that needs to be fixed, too. It seems that only chromium based mobile browsers are affected, I can't reproduce this display errors with e.g. firefox mobile.

I've started this PR with the range to set the sound volume successfully (changed the color to blue instead of dark grey), but I don't know/or find an way **to change the color of the thumb**:

![thumb](https://user-images.githubusercontent.com/59822549/78343046-8e3d0b00-759a-11ea-84ec-2c27b8315d83.jpg)

Anyone having experiences in modifying the css settings and would like to help?

Here are two more display errors I've already identified but haven't discovered the right css modification yet. Any help with this is appreciated!

**Zoned clean up cancel and confirmation area**
Background setting for `.ons-action-sheet-zoned .action-sheet-button--material.action-sheet-button-half` should be `#223344` instead of `#ffffff`:

![zone](https://user-images.githubusercontent.com/59822549/78343785-aa8d7780-759b-11ea-83e1-bd9631678453.jpg)

**Webinterface seetings**
The "active" switches are dark grey (it seems they are deactivated) and the really "disabled" switches are light. Haven't found the right code yet:
![switch](https://user-images.githubusercontent.com/59822549/78344598-e83ed000-759c-11ea-9e37-6113aeb90bd5.jpg)


