### PR TITLE
Add support for operating system theme (prefers-color-scheme:)

### DIFF
--- a/client/css/system-onsen-css-components.min.css
+++ b/client/css/system-onsen-css-components.min.css
@@ -1,0 +1,2 @@
+@import url('onsen-css-components.min.css') screen;
+@import url('dark-onsen-css-components.min.css') screen and (prefers-color-scheme: dark);

--- a/client/index.html
+++ b/client/index.html
@@ -232,8 +232,11 @@
 		.then(res => fn.prequest("api/get_interface_config"))
 		.then(res => {
 			fn.webifSettings = res;
-			if(fn.webifSettings.style === "dark") {
+			if (fn.webifSettings.style === "dark") {
 				document.getElementById('color-theme').setAttribute('href', 'css/dark-onsen-css-components.min.css');
+			}
+			else if (fn.webifSettings.style === "system") {
+				document.getElementById('color-theme').setAttribute('href', 'css/system-onsen-css-components.min.css');
 			}
 			return i18next.use(i18nextXHRBackend).init({
 				interpolation: {

--- a/client/settings-web-interface.html
+++ b/client/settings-web-interface.html
@@ -33,6 +33,7 @@
 				<ons-select id="settings-webif-style" class="settings-webif-select">
 					<option value="">Default</option>
 					<option value="dark">Dark</option>
+					<option value="system">System</option>
 				</ons-select>
 			</div>
 		</ons-list-item>


### PR DESCRIPTION
This adds support dark and default theme to be chossen by the operation system using the css feature [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).