### PR TITLE
Upgrade mqtt to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"express": "^4.17.1",
 		"express-basic-auth": "^1.2.0",
 		"express-dynamic-middleware": "^1.0.0",
-		"mqtt": "^3.0.0",
+		"mqtt": "4.0.0",
 		"multer": "^1.4.2",
 		"pngjs": "^5.0.0",
 		"prettycron": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,10 +1127,10 @@ mqtt-packet@^6.0.0:
     process-nextick-args "^2.0.0"
     safe-buffer "^5.1.2"
 
-mqtt@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mqtt/-/mqtt-3.0.0.tgz#7961e5f61efba3eec37d5aa9c4cbcdeb6f841380"
-  integrity sha512-0nKV6MAc1ibKZwaZQUTb3iIdT4NVpj541BsYrqrGBcQdQ7Jd0MnZD1/6/nj1UFdGTboK9ZEUXvkCu2nPCugHFA==
+mqtt@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mqtt/-/mqtt-4.0.0.tgz#66612c619c942f88d8c239eeced2e08c65e8fb68"
+  integrity sha512-sRfKhSNK4yetSO9EyeXCNByKJiNW9XMtv214sEaXA2cUgeB+DWq9aKOxAdbW1rRbxjiqXPZYyjwt214TTgh0cA==
   dependencies:
     base64-js "^1.3.0"
     commist "^1.0.0"


### PR DESCRIPTION
The current version of mqtt is 3.0.0, which does not support SNI. I am using haproxy with TLS passthrough to mosquitto, and because 3.0.0 doesn't support SNI, it gets served the wrong certificate and errors.

This PR upgrades mqtt to 4.0.0, which does support sending SNI.