### PR TITLE
Remove onsflag-iphonex-portrait in web client

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -284,10 +284,6 @@
 			fn.localize = function() {};
 			console.error('loading interface configuration has failed', e);
 		});
-
-		if (ons.platform.isIPhoneX()) {
-			document.documentElement.setAttribute('onsflag-iphonex-portrait', '');
-		}
 	</script>
 	<div>Loading...</div>
 	<script type="module" crossorigin>


### PR DESCRIPTION
Fixes extra padding in the web ui on iPhones in portrait orientation.

The flag adds top padding to the interface and is intended for use in Cordova apps that consume the entire screen where the notch gets in the way.

Valetudo runs inside of Safari which adds its own status bar and padding so having this enabled results in extra whitespace at the top of the screen.

Here's what the UI looks like on my phone before the patch:
![IMG_22DDB0574EAD-1](https://user-images.githubusercontent.com/945848/90456740-92337a80-e0ae-11ea-9ef4-90ca87d21c12.jpeg)
