### PR TITLE
Updated Spanish locale

### DIFF
--- a/client/locales/es.json
+++ b/client/locales/es.json
@@ -564,8 +564,8 @@
 			"n14": "Actualizando",
 			"n15": "En base",
 			"n16": "Yendo a objetivo",
-			"n17": "Zonas limpiadas",
-			"n18": "Habitaciones limpiadas"
+			"n17": "Limpieza por zonas",
+			"n18": "Limpieza por habitaciones"
 		},
 		"errors": {
 			"n0": "Sin errores",


### PR DESCRIPTION
Fix: “Zone cleanup” was being translated as “zone cleaned up”