### PR TITLE
Add experimental support for roborock s4 devices

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -246,7 +246,7 @@
 						window.fn[name].src = 'img/' + file;
 					});
 				}
-				return Promise.all([ploadImg('robotImg',(fn.device.model === 'rockrobo.vacuum.v1' ? 'robot_v1.png' : 'robot.png')),ploadImg('chargerImg','charger.png')]);
+				return Promise.all([ploadImg('robotImg',((fn.device.model === 'rockrobo.vacuum.v1' || fn.device.model === 'roborock.vacuum.s4') ? 'robot_v1.png' : 'robot.png')),ploadImg('chargerImg','charger.png')]);
 			})
 		}
 

--- a/client/locales/de.json
+++ b/client/locales/de.json
@@ -337,7 +337,7 @@
 		},
 		"persistentData": {
 			"pageTitle": "\"Dauerhafte Daten\"-Konfiguration",
-			"notSupported": "Nur der Roborock S5x unterstützt die permanenten Kartenfunktionen.",
+			"notSupported": "Dieses Gerät unterstützt die permanenten Kartenfunktionen nicht.",
 			"genericConfirm": "Wirklich fortsetzen?",
 			"genericOverwriteWarning": "Zuvor gespeicherte Daten werden überschrieben.",
 			"enableDataTitle": "Dauerhafte Daten (\"lab mode\")",

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -337,7 +337,7 @@
 		},
 		"persistentData": {
 			"pageTitle": "Persistent Data Configuration",
-			"notSupported": "Only Roborock S5x supports the persistent map features.",
+			"notSupported": "Persistent map features are not supported on this device.",
 			"genericConfirm": "Are you sure to proceed?",
 			"genericOverwriteWarning": "Previously saved data will be overwritten.",
 			"enableDataTitle": "Persistent data (\"lab mode\")",

--- a/lib/miio/Vacuum.js
+++ b/lib/miio/Vacuum.js
@@ -1031,6 +1031,13 @@ Vacuum.prototype.detectFeatures = function() {
 						f.rooms = true;
 					}
 					break;
+				case "roborock.vacuum.s4":
+					f.lab = !!res.lab_status;
+					if (res.msg_ver === 3) {
+						f.v3 = true;
+						f.rooms = true;
+					}
+					f.nmop = true;
 				case "roborock.vacuum.t6":
 				case "roborock.vacuum.s6":
 					f.lab = !!res.lab_status;


### PR DESCRIPTION
I like your new device features function! Following the specs of the roborock s4 (hardware comparable to Gen1 with software features of Gen2) I've added this model. Since I don't own an s4 by myself I tagged this PR as "experimental".