### PR TITLE
IOS map pinch zoom bugfix

### DIFF
--- a/client/zone/js-modules/touch-handling.js
+++ b/client/zone/js-modules/touch-handling.js
@@ -243,6 +243,8 @@ export class TouchHandler {
 		evt.stopPropagation();
 		evt.preventDefault();
 
-		this.ongoingGesture = this.ongoingGesture.removePointer(changedTouches[0]);
+		changedTouches.forEach(e => {
+            this.ongoingGesture = this.ongoingGesture.removePointer(e);
+        });
 	}
 }


### PR DESCRIPTION
Bugfix to address [https://github.com/rand256/valetudo/issues/90](https://github.com/rand256/valetudo/issues/90)

PointerUp event seems to work find on Android devices but breaks with IOS when both fingers lifted within the same event.  Original code only handled [0]th element and didn't correctly remove both finger lifts from this same event.