### PR TITLE
remove `water_grade` from `supported_features` list to fix homeassistant autodiscovery

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -164,7 +164,6 @@ const MqttClient = function (valetudo) {
 					"locate",
 					"clean_spot",
 					"fan_speed",
-					"water_grade",
 					"send_command"
 				],
 				command_topic: this.topics.command,


### PR DESCRIPTION
autodiscovery is broken since 0.10.6 with the following error message:

<details>
<summary>Home Assistant 2021.4.6 error log</summary>

```
Exception in async_discover when dispatching 'mqtt_discovery_new_vacuum_mqtt': ({'name': 'rockrobo', 'unique_id': 'rockrobo', 'schema': 'state', 'device': {'manufacturer': 'Roborock', 'model': 'rockrobo.vacuum.v1', 'name': 'rockrobo', 'identifiers': ['rockrobo'], 'sw_version': '0.10.6'}, 'supported_features': ['start', 'pause', 'stop', 'return_home', 'battery', 'status', 'locate', 'clean_spot', 'fan_speed', 'water_grade', 'send_command'], 'command_topic': 'valetudo/rockrobo/command', 'state_topic': 'valetudo/rockrobo/state', 'set_fan_speed_topic': 'valetudo/rockrobo/set_fan_speed', 'set_water_grade_topic': 'valetudo/rockrobo/set_water_grade', 'fan_speed_list': ['whisper', 'min', 'medium', 'high', 'max'], 'water_grade_list': ['off', 'low', 'medium', 'high'], 'send_command_topic': 'valetudo/rockrobo/custom_command', 'json_attributes_topic': 'valetudo/rockrobo/attributes', 'platform': 'mqtt'},) Traceback (most recent call last): File "/usr/src/homeassistant/homeassistant/components/mqtt/mixins.py", line 160, in async_discover config = schema(discovery_payload) File "/usr/local/lib/python3.8/site-packages/voluptuous/validators.py", line 218, in __call__ return self._exec((Schema(val) for val in self.validators), v) File "/usr/local/lib/python3.8/site-packages/voluptuous/validators.py", line 341, in _exec raise e if self.msg is None else AllInvalid(self.msg, path=path) File "/usr/local/lib/python3.8/site-packages/voluptuous/validators.py", line 337, in _exec v = func(v) File "/usr/local/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 272, in __call__ return self._compiled([], data) File "/usr/local/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 817, in validate_callable return schema(data) File "/usr/src/homeassistant/homeassistant/components/mqtt/vacuum/__init__.py", line 19, in validate_mqtt_vacuum return schemas[value[CONF_SCHEMA]](value) File "/usr/local/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 272, in __call__ return self._compiled([], data) File "/usr/local/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict return base_validate(path, iteritems(data), out) File "/usr/local/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping raise er.MultipleInvalid(errors) voluptuous.error.MultipleInvalid: value must be one of ['battery', 'clean_spot', 'fan_speed', 'locate', 'pause', 'return_home', 'send_command', 'start', 'status', 'stop'] @ data['supported_features'][9]
```
</details>

referring to [Vacuum Entity](https://developers.home-assistant.io/docs/core/entity/vacuum/#supported-features) valid features are: 
['battery', 'clean_spot', 'fan_speed', 'locate', 'pause', 'return_home', 'send_command', 'start', 'status', 'stop']