### PR TITLE
remove `water_grade_list` from `autoconf_payloads` list to fix homeassistant autodiscovery

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -171,7 +171,6 @@ const MqttClient = function (valetudo) {
 				set_fan_speed_topic: this.topics.set_fan_speed,
 				set_water_grade_topic: this.topics.set_water_grade,
 				fan_speed_list: Object.keys(FAN_SPEEDS),
-				water_grade_list: Object.keys(WATER_GRADES),
 				send_command_topic: this.topics.send_command,
 				json_attributes_topic: this.topics.attributes
 			}


### PR DESCRIPTION
sorry, but the `water_grade_list` is also invalid. Now it should really work. Sorry for these two pull requests.